### PR TITLE
chore: GitHub repo health — license, templates, badges, metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Something broken on a device running this port
+labels: bug
+---
+
+**Device**: SM-X800 (or variant — X700/X706/X800/X806/X900/X906?)
+**Stock firmware the device shipped from**: (e.g. One UI 7 / X800XXU9DYDC)
+**Kernel package release**: (`uname -v` on the device, or the pkgrel you built)
+**Device package release**: (`apk info device-samsung-gts8pwifi`)
+
+**What happened**
+
+**What you expected**
+
+**Logs** (as applicable)
+```
+dmesg | tail -50
+journalctl -b --no-pager | tail -50   # the journal is persistent; -b -1 for the previous boot
+```
+
+**Notes**: the tablet-side toolkit (`sudo gts8pwifi-setup`) installs the debug
+tools most issues need (evtest, i2c-tools, libgpiod, strace).

--- a/.github/ISSUE_TEMPLATE/variant_report.md
+++ b/.github/ISSUE_TEMPLATE/variant_report.md
@@ -1,0 +1,22 @@
+---
+name: Device variant report
+about: You tried this on another Tab S8 family device (S8 / S8+ 5G / S8 Ultra)
+labels: enhancement
+---
+
+The whole Tab S8 family shares the SM8450 SoC, so much of this port should
+carry over — but only the Wi-Fi S8+ (SM-X800) is tested. Reports from other
+variants are extremely welcome, successful or not.
+
+**Device**: (SM-X700 / X706 / X800 5G-variant / X806 / X900 / X906)
+**Stock firmware**: (One UI version + build)
+**How far did you get?**
+- [ ] Bootloader unlocked (Knox tripped — see README warnings first!)
+- [ ] uniLoader boot with adjusted DTS (qcom,msm-id / board-id from your stock DTB)
+- [ ] Console on panel
+- [ ] Touch / keyboard / WiFi / display / GPU (which?)
+
+**What differed from the SM-X800 instructions**
+
+**Stock DTB observations** (panel name, touch controller, board-id — see
+docs/discovery-notes/00-recon-findings.md for how we mined ours)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What
+
+## Why
+
+## Tested on
+<!-- device + kernel pkgrel, or "build-tested only" — flashing evidence beats theory
+     here; ONE VARIABLE PER FLASH is house style (see docs/06) -->
+
+## Checklist
+- [ ] Patches (if any) generated with `tools/mkpatch`, never hand-written
+- [ ] No Samsung-proprietary content (blobs, dumps, stock DTBs) — extractors only
+- [ ] Docs updated if behavior/status changed (README table, docs/, tools/README)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+# License
+
+This repository intentionally carries two licenses, following the upstream
+projects each part feeds into:
+
+| Path | License | Rationale |
+|---|---|---|
+| `pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/` (DTS, drivers, patches, config) | **GPL-2.0-only** | Linux kernel sources — several drivers are derived from Samsung's GPL downstream kernel |
+| `pmaports-overlay/uniloader-port/` | **GPL-2.0-only** | uniLoader is GPL-2.0 |
+| `pmaports-overlay/device/testing/device-samsung-gts8pwifi/` (packaging, scripts) | **MIT** | postmarketOS device packages are conventionally MIT |
+| `docs/`, `device-facts/`, `tools/` (documentation, runbooks, helpers) | **MIT** | Maximum reuse for other porters |
+
+Full license texts: [GPL-2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt)
+· [MIT](https://opensource.org/license/mit)
+
+Not covered by any license here because it is **never in this repository**:
+Samsung's proprietary content (firmware blobs, stock partition dumps, stock
+DTBs). The repo ships extractors (`gts8pwifi-fw-extract`) so you pull those
+from your own device — see the README's "Should you try this?" section.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Samsung Galaxy Tab S8+ (SM-X800) — mainline Linux / postmarketOS port
 
+![License](https://img.shields.io/badge/license-GPL--2.0%20%2B%20MIT-blue)
+![Kernel](https://img.shields.io/badge/kernel-6.13--rc3%20(sm8450--mainline)-informational)
+![UI](https://img.shields.io/badge/desktop-KDE%20Plasma%206-brightgreen)
+![GitHub last commit](https://img.shields.io/github/last-commit/aaronsb/sm-x800-linux)
+![GitHub stars](https://img.shields.io/github/stars/aaronsb/sm-x800-linux?style=social)
+
 Mainline Linux runs **usably** on the Galaxy Tab S8+ Wi-Fi (`gts8pwifi`, Qualcomm
 SM8450 "Waipio"): kernel 6.13-rc3, all 8 cores, a **native KMS display driver**
 (our S6TUUM1 panel driver — DSC, 120 Hz, real power management) on the 2800×1752
@@ -221,5 +227,14 @@ not publicly available).
 
 ## License
 
-Port sources (DTS, board file, packaging) follow their upstream projects:
-GPL-2.0-only for kernel/uniLoader sources, MIT for the pmaports device package.
+Dual, following each part's upstream: GPL-2.0-only for kernel/uniLoader sources,
+MIT for packaging, docs, and tools — the per-directory table is in
+[LICENSE.md](LICENSE.md). Samsung-proprietary content is never in this repo;
+extractors pull it from your own device.
+
+## Contributing
+
+Issues and PRs welcome — especially [device variant reports](.github/ISSUE_TEMPLATE/variant_report.md)
+from the rest of the Tab S8 family (same SoC). House style: one variable per
+flash, patches via `tools/mkpatch` (never hand-written), evidence over theory —
+see `docs/06-upstreaming.md` for the conventions.


### PR DESCRIPTION
## What
LICENSE.md (dual-license table), issue templates (bug + device-variant report), PR template, README badges + Contributing section, repo description/topics.

## Why
Just went public on r/mobilelinux — fresh visitors need license clarity, structured issue intake (especially variant reports from the rest of the Tab S8 family), and discoverable metadata.

## Tested on
Docs/metadata only — no device impact. Badges verified against shields.io URL format; templates follow GitHub's ISSUE_TEMPLATE conventions.