### PR TITLE
S Pen bring-up + firmware harvest pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OS_PATCH    := 2025-04
 
 .PHONY: help deps kernel uniloader bootimg boot flash flash-full flash-rootfs \
         sparse flash-all flash-stay flash-help restore-android sync-aports uuids \
-        rootfs stage-fw manifest toolchain \
+        rootfs stage-fw manifest toolchain check-tools \
         sync-overlay lint clean distclean device-status dtb-dump
 
 help: ## Show available targets
@@ -73,6 +73,24 @@ toolchain: ## Install the aarch64 cross toolchain into the pmb chroot
 	@# pmb build --force zaps the chroot, so this is re-run by other targets
 	$(PMB) chroot -- apk add build-base gcc-aarch64 binutils-aarch64 \
 	    make bison flex >/dev/null 2>&1 || true
+
+# Host tools the harvest + build + flash paths need. Required tools fail the
+# target; optional ones only warn. Firmware harvest from a stock super.img
+# needs lpunpack (vendor split) and an erofs reader (mount or fsck.erofs);
+# sparse dumps need simg2img; DTB inspection needs dtc; flashing needs odin4.
+check-tools: ## Verify host tools for harvest/build/flash are installed
+	@echo ">> required:"; rc=0; \
+	for t in lpunpack simg2img dtc; do \
+	    if command -v $$t >/dev/null; then echo "   ok   $$t"; \
+	    else echo "   MISS $$t"; rc=1; fi; done; \
+	if command -v fsck.erofs >/dev/null || command -v dump.erofs >/dev/null; then \
+	    echo "   ok   erofs-utils (fsck.erofs/dump.erofs)"; \
+	else echo "   MISS erofs-utils  (pacman -S erofs-utils)"; rc=1; fi; \
+	echo ">> optional:"; \
+	for t in odin4 sshpass; do \
+	    command -v $$t >/dev/null && echo "   ok   $$t" || echo "   --   $$t (only needed for flash/on-device)"; done; \
+	test $$rc -eq 0 && echo ">> all required host tools present" \
+	    || { echo "!! missing required host tools (see above)"; exit 1; }
 
 ## ---------------------------------------------------------------------------
 ## Build

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ DPU/DSI/DSC pipeline, with the pogo Book Cover Keyboard doing the driving.*
 | `reboot download` from Linux | 🟡 PON `mode-download` wired but ABL ignores it — likely cold reset clears the spare bits (downstream forces a warm reset first); under investigation |
 | USB gadget | ❌ needs Type-C/`pmic_glink` described |
 | Native panel driver (S6TUUM1 DDIC) | ✅ working — full native KMS: cold init (Anapass TCON-ready handshake), DSC @ 2800×1752, TE-synced 120 Hz, DPMS blank/unblank, brightness (11-bit DBV). Story: device-facts/display-s6tuum1.md |
-| S Pen (Wacom EMR digitizer) | ❌ not started (separate chip, separate bus) |
+| S Pen (Wacom WEZ01 EMR digitizer) | ✅ working — our `wacom-wez01` driver; position + pressure + tool. SE14's FIFO is silicon-disabled (forces broken GPI DMA), so we bit-bang i2c on its pins via `i2c-gpio`. Firmware `wez01_gts8p.bin` (harvested). Polish: query/calibration + axis verify. Story: device-facts/wacom-wez01.md |
 | GPU (Adreno 730) | ✅ working — freedreno/Mesa `FD730`, OpenGL ES 3.2; Samsung-signed zap from the `apnhlos` partition (`gts8pwifi-fw-extract`), firmware rides in the initramfs (a7xx loads SQE at bind time) |
 | Plasma Desktop 6 (KWin Wayland) | ✅ working — full KDE 6.7 desktop, KWin composited on the Adreno, Plasma Login Manager autostart; one command on a fresh install: `sudo gts8pwifi-setup plasma`. Polish gaps: tear bands under fast motion (panel idles at ~24 Hz LFD), no runtime 120 Hz switching yet |
 | Login experience | ✅ quiet boot (`loglevel=4`), generated `/etc/issue` banner with live IP (agetty needs `--issue-file` on Alpine), UTF-8 locale, keyboard autorepeat (kernel r42) |

--- a/device-facts/wacom-wez01.md
+++ b/device-facts/wacom-wez01.md
@@ -102,18 +102,30 @@ Wire-in mirrors the others in `linux-postmarketos-qcom-sm8450/APKBUILD`
 (`cp` the file, append `obj-y += wacom-wez01.o` to the target dir's Makefile), and
 flip the DT `compatible` to whatever string the new driver matches.
 
-## Bring-up status (r44 + driver) — BLOCKED on GPI DMA
+## Bring-up status — WORKING (via i2c-gpio bit-bang)
 
-The driver (`wacom-wez01.c`) is written and builds into the kernel. On-device it
-**binds and works to the edge of the bus**:
+**The S Pen draws.** Position, pressure, and tool detection all work: `ABS_X/ABS_Y`
+track strokes smoothly, `ABS_PRESSURE` reports analog force (measured to ~3500 of
+4095), `BTN_TOOL_PEN` on proximity — clean, no bus errors. The fix was to move the
+pen off geni (which is forced to broken GPI DMA on SE14) onto a **software
+bit-banged `i2c-gpio` bus** on the same pins (gpio52/53). See the DTS comment on
+`&wacom_i2c`.
 
-- probes, registers input `Wacom WEZ01 S Pen` (event4), requests IRQ (gpio51 →
-  virq 187), claims `0x56` (`UU`).
-- the IRQ is real: **704 interrupts while drawing** — the digitizer senses the pen
-  and signals data-ready.
+Open polish (not blockers):
+- `wacom_i2c_query` (`COM_QUERY` write, then 32-byte read) still returns -5 even
+  post-boot, so the driver runs on fallback `max_x/max_y` — calibration is
+  approximate. Likely the query wants a repeated-start (combined write+read via a
+  2-message `i2c_transfer`, which the bit-bang bus supports) rather than two
+  separate transactions; or the reply arrives via IRQ. Fixing it gives exact
+  geometry + an `mpu == 0x46` liveness check.
+- Axis orientation (hardcoded from stock `wacom,invert = <0 1 1>`) not yet
+  verified against the panel with directed strokes.
+- Tilt/height reported but not eyeballed.
 
-But **every i2c read on the bus fails**, so no packet is ever parsed and event4
-stays silent:
+## History: why geni/GPI DMA did not work (the road here)
+
+The first attempt put the pen on geni `&i2c14` (SE14). The driver bound and the
+IRQ fired (704x while drawing), but **every read failed**:
 
 ```
 gpi a00000.dma-controller: not enough space in ring, avail:0 required:1

--- a/device-facts/wacom-wez01.md
+++ b/device-facts/wacom-wez01.md
@@ -101,3 +101,52 @@ gestures, the garage/dock notifications, factory sysfs.
 Wire-in mirrors the others in `linux-postmarketos-qcom-sm8450/APKBUILD`
 (`cp` the file, append `obj-y += wacom-wez01.o` to the target dir's Makefile), and
 flip the DT `compatible` to whatever string the new driver matches.
+
+## Bring-up status (r44 + driver) — BLOCKED on GPI DMA
+
+The driver (`wacom-wez01.c`) is written and builds into the kernel. On-device it
+**binds and works to the edge of the bus**:
+
+- probes, registers input `Wacom WEZ01 S Pen` (event4), requests IRQ (gpio51 →
+  virq 187), claims `0x56` (`UU`).
+- the IRQ is real: **704 interrupts while drawing** — the digitizer senses the pen
+  and signals data-ready.
+
+But **every i2c read on the bus fails**, so no packet is ever parsed and event4
+stays silent:
+
+```
+gpi a00000.dma-controller: not enough space in ring, avail:0 required:1
+geni_i2c a98000.i2c: prep_slave_sg failed
+geni_i2c a98000.i2c: GPI transfer failed: -5
+```
+
+Root cause chain, established from the mainline sources:
+
+1. **SE14 is hardware-forced to GPI DMA.** `i2c-qcom-geni` reads `fifo_disable`
+   from the SE's `GENI_IF_DISABLE_RO` register — SE14's FIFO interface is disabled
+   in silicon, so `gpi_mode = true` is forced; there is no FIFO fallback. (This is
+   why the FIFO bus i2c8/touch works and i2c14 does not — different HW, not the
+   driver.) Small 1-byte reads (`i2cdetect -r`) went through in the probe-only
+   boot, but the driver's 17-/32-byte reads all take the GPI path.
+2. **The GPI channel's ring is empty from the first transfer.** `gpi.c` reports
+   `avail:0` of `CHAN_TRES = 64` on transfer #1. The ring's read pointer only
+   advances as GPI *completion events* are processed, so avail:0 at the start
+   means the channel was never brought to a running/reset state with credit — a
+   GPI channel-start problem, not a ring overrun.
+3. It is **persistent**: once wedged, even manual `i2ctransfer` reads keep failing
+   until a reset. The level-triggered pen IRQ then storms (failed read never
+   deasserts the line) — the console spam the user saw.
+
+The DT wiring is NOT the bug: mainline `sm8450.dtsi` gives i2c14
+`dmas = <&gpi_dma1 0 6 QCOM_GPI_I2C>` (SE14 = 7th SE on QUP1 = index 6), which is
+correct. i2c8–i2c12 have no `dmas` (FIFO), so **i2c14 may be the first real
+consumer of the `gpi_dma1` (a00000) controller** — plausibly why its channel
+start path is exercising an untested/broken corner.
+
+Next avenues (not yet tried): confirm `gpi_dma1` actually probed and its GPII for
+this channel started (instrument `gpi_alloc_chan`/`gpi_start_chan` in `gpi.c`);
+check for a mainline GPI-DMA fix for sm8450 QUP1; compare against a known-good GPI
+consumer (a QUP1 SPI in GPI mode). This is a SoC DMA-plumbing problem in the class
+of "hard SoC integration," distinct from the driver, which is ready to run the
+moment a read succeeds.

--- a/device-facts/wacom-wez01.md
+++ b/device-facts/wacom-wez01.md
@@ -1,0 +1,103 @@
+# S Pen — Wacom WEZ01 EMR digitizer (gts8pwifi)
+
+Bring-up reference for the S Pen digitizer. Status: **chip proven alive on the
+bus; no driver yet.** The DT wiring below is merged and flashed (r44); the driver
+is the remaining work.
+
+## Identity & bus
+
+| | |
+|---|---|
+| Part | Wacom WEZ01 EMR digitizer (`compatible = "wacom,w90xx"`, MPU id `0x46`) |
+| Bus | QUP **SE14** = `i2c@a98000` = mainline **`&i2c14`**, 400 kHz, pins gpio52/53 |
+| Address | `0x56` |
+| Firmware | `wez01_gts8p.bin` (harvested; `tools/fw-manifest.tsv`) — NOT needed to read the chip; it already runs its app firmware |
+| Downstream driver | `kernel-src/drivers/input/wacom/` (10k lines, sec_input framework) |
+
+Mapping was recovered from the resolved stock DTB (`device-facts/dt/stock-fdt.dtb`
+→ `qupv3_se14_i2c: i2c@a98000` → `wacom@56`). SE14 shares the QUP1 wrapper with
+the working touch bus (`&i2c8`), so the GPI-DMA deferred-probe cascade that
+plagued i2c8 bring-up does not re-apply.
+
+## Wiring (merged into sm8450-samsung-gts8pwifi.dts)
+
+```
+irq  -> &tlmm 51  (epen-int,  input, IRQ_TYPE_LEVEL_LOW)
+fwe  -> &tlmm 54  (epen-fwe,  flash-enable, driver-owned)
+pdct -> &tlmm 155 (epen-pdct, pen-detect / garage, input)
+avdd -> wacom_avdd (regulator-fixed on &tlmm 167, active-high)
+```
+
+`wacom_avdd` is `regulator-always-on` **as a bring-up crutch** so the chip powers
+up with no driver — drop that once the driver owns the rail (as stm32-pogo did
+for `pogo_vddo`).
+
+## Probe result (r44, on-device)
+
+`i2cdetect -y -r <SE14 bus>` → **`0x56` ACKs.** The bus maps to `/dev/i2c-3`
+(of_node `i2c@a98000`); the `/dev/i2c-N` index is assigned by probe order, so map
+by of_node, not by "14". `&i2c14` probed clean — no `a98000`/storage entry in
+`/sys/kernel/debug/devices_deferred` (only the pre-existing audio/LPASS stalls).
+The FTS capacitive touchscreen does **not** see the EMR pen (0 bytes on event2
+while drawing), as expected for a passive EMR stylus.
+
+## Protocol (from the downstream driver)
+
+**Query** — send `COM_QUERY` (`0x2A`), read back a buffer; the query block starts
+where `query[0] == 0x0F` (EPEN_REG_HEADER). Big-endian pairs:
+
+```
+max_x        = query[1]<<8 | query[2]
+max_y        = query[3]<<8 | query[4]
+max_pressure = query[5]<<8 | query[6]
+fw_ver       = query[7], query[8]
+mpu_ver      = query[9]     # expect 0x46 (WEZ01) — a live sanity check
+bl_ver       = query[10]
+tilt_x/y     = query[11], query[12]
+height       = query[13]
+```
+
+**Coordinate packet** — `COM_COORD_NUM = 16` bytes (read 17). `data[0]` is the
+header; low nibble is the packet type (`NOTI_PACKET = 13`, else pen data):
+
+```
+prox   = data[0] & 0x10      # pen in range (hover)
+side   = data[0] & 0x20      # side button
+eraser = data[0] & 0x40      # tool = rubber, else pen
+x        = data[1]<<8 | data[2]
+y        = data[3]<<8 | data[4]
+pressure = data[5]<<8 | data[6]
+# tilt_x/tilt_y/height live in the later bytes — confirm exact offsets
+# against a raw packet dump (see below); the AOP handler reuses data[6]
+# for mode/wakeup, so the screen-on layout must be read from the main path.
+```
+
+Axis fixups (stock): landscape frame is `xy_switch` + one inverted axis; stock
+`wacom,invert = <0 1 1>`. The panel is 2800×1752 landscape (same physical flip as
+the touchscreen — see the fts axis note in the DTS).
+
+Start/stop sampling: `COM_SAMPLERATE_START` (`0x31`) / `COM_SAMPLERATE_STOP`
+(`0x30`); survey/scan modes at `0x2B`–`0x3B`. See `wacom_reg.h`.
+
+## Port plan
+
+Distill the downstream driver into a single mainline file
+(`drivers/input/touchscreen/wacom-wez01.c` or `input/misc`), the way `fts1ba90a.c`
+(620 lines) distilled the FTS driver — dropping `sec_input`/`sec_cmd`, the factory
+`wacom_i2c_sec.c`, `wacom_i2c_elec.c`, and (for the first cut) `wez01_flash.c`.
+
+First-cut scope — just make it draw:
+1. probe: get `wacom_avdd` regulator, request the three gpios, request the IRQ.
+2. power on, `COM_QUERY`, verify `mpu_ver == 0x46`, read max_x/max_y/pressure.
+3. register an input device (ABS_X/ABS_Y/ABS_PRESSURE/ABS_DISTANCE/ABS_TILT_X/Y,
+   BTN_TOUCH/BTN_TOOL_PEN/BTN_TOOL_RUBBER/BTN_STYLUS).
+4. threaded IRQ: read 17 bytes, **log the raw packet during bring-up**, parse per
+   the layout above, emit events. Apply xy_switch + invert for the landscape frame.
+5. `COM_SAMPLERATE_START` to begin reporting.
+
+Defer to later: firmware flash (`wez01_flash.c`), BLE pen charging, AOP/screen-off
+gestures, the garage/dock notifications, factory sysfs.
+
+Wire-in mirrors the others in `linux-postmarketos-qcom-sm8450/APKBUILD`
+(`cp` the file, append `obj-y += wacom-wez01.o` to the target dir's Makefile), and
+flip the DT `compatible` to whatever string the new driver matches.

--- a/docs/09-firmware-harvest.md
+++ b/docs/09-firmware-harvest.md
@@ -1,0 +1,98 @@
+# Phase 9 — Firmware blob harvest (the cartridge-dump pattern, generalized)
+
+Device: SM-X800 (gts8pwifi), One UI 7 stock. Host: Arch.
+
+Mainline Linux on this tablet needs a handful of Samsung/Qualcomm firmware blobs
+that **no repo and no package may ship** — they are copyrighted and, in the GPU's
+case, TrustZone-signed for this device. The port already solved this for the GPU
+zap shader with a one-off extractor. This phase turns that one-off into a
+**manifest-driven pattern**: declare a blob once, and the build harvests it from
+the builder's own stock firmware.
+
+## The model
+
+**Cartridge-dump.** We distribute the *extractor*, never the *bytes*. Every blob
+lives in the builder's own stock firmware — which they already have, because you
+cannot get to a flashable state without it (Odin AP/BL/CSC, One UI ~7.0). The
+build reads those blobs out of a partition dump and stages them; nothing
+copyrighted ever leaves the owner's device.
+
+## The flow
+
+Harvest happens **once, pre-flash, while the device is still rooted on stock** —
+not repeatedly on the running port. That ordering is the point: it lets the build
+*prove it has every required blob before the user commits to flashing*, so a bad
+or incomplete harvest is caught while the tablet is still trivially recoverable.
+
+1. **Unlock + root on stock** — `docs/01-unlock-root-runbook.md`.
+2. **Dump the blob-bearing partitions** off the rooted device. The runbook's
+   step-8 `dd` backup already does this for `super` (and friends); harvest needs
+   **`apnhlos`** (the zap) and **`super`** (everything else) at minimum.
+3. **Turn the raw images into source roots** on the host:
+   - `apnhlos` — plain vfat: `mount -o ro,loop apnhlos.img /mnt/apnhlos`
+   - `vendor`  — EROFS logical image inside `super`:
+     `lpunpack --partition vendor super.img . && mount -o ro,loop vendor.img /mnt/vendor`
+   (`tools/fw-harvest.sh --from-dumps DIR` does both when erofs/lp tooling is present.)
+4. **Harvest, offline, at leisure** — before flashing:
+   ```sh
+   tools/fw-harvest.sh --apnhlos /mnt/apnhlos --vendor /mnt/vendor \
+                       --out root-build/stock-extract/harvest
+   ```
+5. **Build gate** — the build stages from the harvest tree and HARD-FAILS if a
+   blob a bring-up feature depends on is missing (the same discipline `make
+   stage-fw` already applies to the zap).
+
+## The manifest
+
+One row per blob in [`tools/fw-manifest.tsv`](../tools/fw-manifest.tsv); the
+harvester reads it and `--list` prints it. Columns: `name, source, src_glob,
+dest_dir, tier, class, status, notes`. To enroll a new blob, add a row — no new
+script.
+
+| name | source | class | status | what it is |
+|---|---|---|---|---|
+| `a730_zap`   | apnhlos | pil | working | GPU zap shader — the working reference |
+| `wez01_pen`  | vendor  | mcu | wip     | **S Pen** Wacom W90xx digitizer (i2c 0x56) |
+| `fts_touch`  | vendor  | mcu | working | Touchscreen (STM FTS1BA90A) — already ported |
+| `stm32_pogo` | vendor  | mcu | working | Pogo keyboard MCU — already ported |
+| `camera_icp` | vendor  | pil | none    | Camera ISP microcontroller |
+| `eva`        | vendor  | pil | none    | EVA computer-vision engine |
+| `vpu`        | vendor  | pil | none    | Iris video codec (signed + `_unsigned` both ship) |
+| `cs35l45`    | vendor  | dsp | none    | Cirrus speaker-amp DSP (audio path) |
+| `cs40l26`    | vendor  | dsp | none    | Cirrus haptics DSP |
+| `mfc`        | vendor  | mcu | none    | Wireless-charging IC MCU |
+| `ois`        | vendor  | mcu | none    | Camera OIS STM32G MCU |
+
+## Three classes of blob (and where the S Pen actually sits)
+
+The exploration that kicked this off asked whether the pen is a signed blob we
+can extract "like the GPU." It is extractable — but it is **not** the GPU's
+class, and the distinction is what makes the manifest have a `class` column:
+
+- **`pil`** — Qualcomm PIL/MDT images (`.mdt` + `.bNN` splits), ELF Xtensa,
+  **TrustZone-authenticated**: the SoC's secure world refuses to load them
+  without Samsung's signature. The zap is one. Camera ICP, EVA, and VPU are the
+  other esoteric ones. These are the true "signed blobs."
+- **`mcu`** — a raw firmware image the peripheral's **own driver flashes over
+  i2c/spi**. No SoC signature gate. The **S Pen** (`wez01_gts8p.bin`),
+  touchscreen, and pogo keyboard are all this class — which is why the pen is the
+  *gentlest* introduction: no signing to satisfy. The hard part is the mainline
+  Wacom driver + I²C bus + DT node, not the blob. The downstream driver already
+  sits in `kernel-src/drivers/input/wacom/` (`compatible = "wacom,w90xx"`,
+  `wacom,fw_path`, `wacom,use_garage` = the pen dock).
+- **`dsp`** — Cirrus codec firmware (`.wmfw` + tuning `.bin`), loaded by ASoC at
+  card probe. The `cs35l45` amp is live on the (still-blocked) audio path.
+
+## Status
+
+- **Built and tested:** the manifest + `tools/fw-harvest.sh`, validated against
+  the local `super`/vendor dump — 10/10 vendor blobs harvested, PIL split-sets
+  handled (24 `CAMERA_ICP.*`, 22 `evass.*`, 4 `vpu`), `apnhlos` skipped cleanly
+  when not supplied.
+- **Not yet wired:** the build-side gate (generalize `make stage-fw` /
+  `60-gts8pwifi-gpu-fw.files` to read the manifest and hard-fail per required
+  blob), and `--from-dumps` end-to-end (needs erofs-utils or the erofs kernel
+  module on the host — absent on this Arch box at time of writing).
+- **Relationship to the on-device extractor:** `gts8pwifi-fw-extract` (runtime,
+  mounts `apnhlos` on the running port) stays as a fallback for the zap. The
+  pre-flash harvest is the primary, scalable path.

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/APKBUILD
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/APKBUILD
@@ -38,6 +38,7 @@ source="
 	sm8450-samsung-gts8pwifi.dts
 	fts1ba90a.c
 	stm32-pogo.c
+	wacom-wez01.c
 	max77705-otg.c
 	panel-samsung-s6tuum1.c
 	dpu-dsc-topology-wide-mode.patch
@@ -74,6 +75,14 @@ prepare() {
 	cp "$srcdir"/stm32-pogo.c drivers/input/keyboard/stm32-pogo.c
 	if ! grep -q "stm32-pogo.o" drivers/input/keyboard/Makefile; then
 		echo 'obj-y += stm32-pogo.o' >> drivers/input/keyboard/Makefile
+	fi
+
+	# S Pen: our wacom-wez01 port (see the file's header + device-facts/
+	# wacom-wez01.md). Same obj-y staging into the touchscreen dir, which is
+	# already built via CONFIG_INPUT_TOUCHSCREEN=y.
+	cp "$srcdir"/wacom-wez01.c drivers/input/touchscreen/wacom-wez01.c
+	if ! grep -q "wacom-wez01.o" drivers/input/touchscreen/Makefile; then
+		echo 'obj-y += wacom-wez01.o' >> drivers/input/touchscreen/Makefile
 	fi
 
 	# MAX77705 OTG VBUS boost (USB host-mode power), same pattern.
@@ -129,6 +138,7 @@ sha512sums="
 136b1db8d20cff45a1cdca0c1f9c2520f3728941fc3f0d4bcc9fff649fb8cbc2320472ab62795857cd30311e326dadaaf9f85f71361367bb8aae0c1bfa254402  sm8450-samsung-gts8pwifi.dts
 b1ba6dfd005f084f98eb8d2fe1e8dd82377712f39d2422997b70eaffa9c6b54846c04b43839fc2d462734ef510390bc8e7f7a8f00ffc43ba632011839b1fc5c1  fts1ba90a.c
 be657f3f7ed60bdff1067fade2383bb15bb6493ea5c5398c039549b0a32acae57ac7a93ffd8f4ab28239ed4a8aa78f6dfd8f4169f6d4951d2cda0b1b14ec3152  stm32-pogo.c
+2f731553747aaa09d4bae6836ab3d8d229572f0a462415873f3606a60974b596d4f71f4d74e5b4963d33304c78499ce31f6a6e4a18c97b9c9d907241dae1bf9b  wacom-wez01.c
 eafe3ac70d1330972f5f9e3f6fc828c3dff00beba6526da55884b0ce9593a0cf991a9ae1a21fd7aef3a24981d5dc4d5d7fc593e93e1103250b0cae2b9ecc2f77  max77705-otg.c
 b6f67c8bf3d2c67b77aa79a741f5ae0d1cbad09d890782ab07a724f08dd3b982e4633d369a5333351cf893ee9a4353ed50ce8b268c2d57724c758ccd900a6ae1  panel-samsung-s6tuum1.c
 c6888977944be4c8ecd8bc9670aafe60883939f6d44c362b16946b2783bbc6f72ac607b8c3e2f6ce53a1dc09a34cdb13f14178a7e33571e23bd5853bb2b4cf89  dpu-dsc-topology-wide-mode.patch

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/pmos.config
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/pmos.config
@@ -78,3 +78,4 @@ CONFIG_REGULATOR_USERSPACE_CONSUMER=y
 # Native display: MSM DRM (DPU+DSI) with our S6TUUM1 panel driver (staged by
 # the APKBUILD). simpledrm hands off via the aperture helper at msm probe.
 CONFIG_DRM_MSM=y
+CONFIG_I2C_GPIO=y

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/sm8450-samsung-gts8pwifi.dts
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/sm8450-samsung-gts8pwifi.dts
@@ -711,6 +711,14 @@
 		bias-disable;
 		input-enable;
 	};
+
+	/* Bit-banged i2c on the SE14 pins for the S Pen (see &wacom_i2c). */
+	wacom_i2c_gpio: wacom-i2c-gpio-state {
+		pins = "gpio52", "gpio53";	/* SE14 SDA / SCL */
+		function = "gpio";
+		bias-pull-up;
+		drive-strength = <2>;
+	};
 };
 
 /*
@@ -1091,43 +1099,63 @@
 };
 
 /*
- * S Pen — Wacom W90xx EMR digitizer, i2c 0x56 on QUP se14 (&i2c14, pins
- * gpio52/53). Mapped from the stock DTB (qupv3_se14_i2c: i2c@a98000 ->
- * wacom@56). SE14 shares the QUP1 wrapper with the working touch bus
- * (&i2c8), so the GPI-DMA deferred-probe cascade that plagued i2c8 bring-up
- * does not re-apply here — that wrapper's DMA engine is already up.
+ * S Pen — Wacom W90xx EMR digitizer, i2c 0x56, on the SE14 pins (gpio52 SDA /
+ * gpio53 SCL). Mapped from the stock DTB (qupv3_se14_i2c: i2c@a98000 ->
+ * wacom@56).
  *
- * There is no mainline driver for this Samsung EMR part yet (the downstream
- * driver lives in kernel-src/drivers/input/wacom/). This node is staged for
- * the PROBE-FIRST milestone: with AVDD always-on (wacom_avdd) the chip
- * should ACK at 0x56 under `i2cdetect -y -r <bus>` even before a driver
- * exists. Wiring transcribed from the stock wacom@56:
- *   irq  -> &tlmm 51  (epen-int,  input, level-low)
- *   fwe  -> &tlmm 54  (epen-fwe,  flash-enable, driver-owned)
- *   pdct -> &tlmm 155 (epen-pdct, pen-detect, input)
- *   avdd -> wacom_avdd (tlmm 167 fixed reg)
+ * WHY BIT-BANG AND NOT geni: SE14's FIFO interface is disabled in silicon
+ * (GENI_IF_DISABLE_RO), so geni-i2c is forced into GPI DMA — and that DMA
+ * path fails for this chip. Bare idle reads work, but combined write+read
+ * transactions return "DMA txn failed:3" and active-data reads (the chip
+ * clock-stretches while computing a sample) wedge the GPI ring (avail:0),
+ * which does not recover. So we disable geni on SE14 and drive the same two
+ * pins as a software-bit-banged i2c-gpio bus: no DMA ring, and clock-
+ * stretching is handled natively. The pen's ~120 Hz / 17-byte traffic is well
+ * within a 100 kHz bit-bang budget. The full diagnosis is in
+ * device-facts/wacom-wez01.md. The wacom driver is bus-agnostic (plain
+ * i2c_master_send/recv), so it needs no change.
+ *
+ * Wiring transcribed from the stock wacom@56:
+ *   sda/scl -> &tlmm 52 / 53 (open-drain, pull-up; see wacom_i2c_gpio)
+ *   irq     -> &tlmm 51  (epen-int,  input, level-low)
+ *   fwe     -> &tlmm 54  (epen-fwe,  flash-enable, driver-owned)
+ *   pdct    -> &tlmm 155 (epen-pdct, pen-detect, input)
+ *   avdd    -> wacom_avdd (tlmm 167 fixed reg)
  *   firmware wez01_gts8p.bin (harvested; tools/fw-manifest.tsv)
  */
+/* geni on SE14 is disabled — its pins are bit-banged by &wacom_i2c below. */
 &i2c14 {
-	clock-frequency = <400000>;
-	status = "okay";
+	status = "disabled";
+};
 
-	wacom@56 {
-		compatible = "wacom,w90xx";
-		reg = <0x56>;
-
-		interrupt-parent = <&tlmm>;
-		interrupts = <51 IRQ_TYPE_LEVEL_LOW>;
-
+/ {
+	wacom_i2c: i2c-wacom {
+		compatible = "i2c-gpio";
+		sda-gpios = <&tlmm 52 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&tlmm 53 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;	/* ~100 kHz half-period; conservative for internal pull-ups */
 		pinctrl-names = "default";
-		pinctrl-0 = <&wacom_irq_default>, <&wacom_pdct_default>;
+		pinctrl-0 = <&wacom_i2c_gpio>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		vdd-supply = <&wacom_avdd>;
+		wacom@56 {
+			compatible = "wacom,w90xx";
+			reg = <0x56>;
 
-		wacom,irq-gpio = <&tlmm 51 GPIO_ACTIVE_LOW>;
-		wacom,fwe-gpio = <&tlmm 54 GPIO_ACTIVE_HIGH>;
-		wacom,pdct-gpio = <&tlmm 155 GPIO_ACTIVE_LOW>;
-		wacom,fw_path = "wez01_gts8p.bin";
+			interrupt-parent = <&tlmm>;
+			interrupts = <51 IRQ_TYPE_LEVEL_LOW>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&wacom_irq_default>, <&wacom_pdct_default>;
+
+			vdd-supply = <&wacom_avdd>;
+
+			wacom,irq-gpio = <&tlmm 51 GPIO_ACTIVE_LOW>;
+			wacom,fwe-gpio = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+			wacom,pdct-gpio = <&tlmm 155 GPIO_ACTIVE_LOW>;
+			wacom,fw_path = "wez01_gts8p.bin";
+		};
 	};
 };
 

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/sm8450-samsung-gts8pwifi.dts
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/sm8450-samsung-gts8pwifi.dts
@@ -210,6 +210,24 @@
 	};
 
 	/*
+	 * S Pen (Wacom W90xx EMR digitizer) AVDD. Stock models it as a
+	 * GPIO-switched fixed regulator (fixed_regulator0, tlmm 167, active
+	 * high). regulator-always-on for now: the pen has no mainline driver
+	 * yet, so nothing else would enable the rail — always-on lets the chip
+	 * power up so its i2c presence (0x56 on &i2c14) can be probed. Once a
+	 * wacom driver lands it should own this rail (drop always-on), the way
+	 * the stm32-pogo driver took over pogo_vddo.
+	 */
+	wacom_avdd: regulator-wacom-avdd {
+		compatible = "regulator-fixed";
+		regulator-name = "wacom_avdd";
+		gpio = <&tlmm 167 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	/*
 	 * Manual switch for tablet-sourced USB VBUS (the MAX77705 OTG boost,
 	 * see charger@69). regulator-output is the mainline convention for a
 	 * userspace-switched rail: it surfaces
@@ -674,6 +692,25 @@
 		bias-disable;
 		input-enable;
 	};
+
+	/*
+	 * S Pen (Wacom) lines, from the stock epen-int-active / epen-pdct-active
+	 * states: both inputs, bias-disable. The fwe line (gpio54) is driven by
+	 * the driver directly, so it gets no pin state here.
+	 */
+	wacom_irq_default: wacom-irq-default-state {
+		pins = "gpio51";		/* wacom,irq-gpio (epen-int) */
+		function = "gpio";
+		bias-disable;
+		input-enable;
+	};
+
+	wacom_pdct_default: wacom-pdct-default-state {
+		pins = "gpio155";		/* wacom,pdct-gpio (epen-pdct) */
+		function = "gpio";
+		bias-disable;
+		input-enable;
+	};
 };
 
 /*
@@ -1050,6 +1087,47 @@
 		touchscreen-size-y = <2800>;
 		touchscreen-swapped-x-y;
 		touchscreen-inverted-x;
+	};
+};
+
+/*
+ * S Pen — Wacom W90xx EMR digitizer, i2c 0x56 on QUP se14 (&i2c14, pins
+ * gpio52/53). Mapped from the stock DTB (qupv3_se14_i2c: i2c@a98000 ->
+ * wacom@56). SE14 shares the QUP1 wrapper with the working touch bus
+ * (&i2c8), so the GPI-DMA deferred-probe cascade that plagued i2c8 bring-up
+ * does not re-apply here — that wrapper's DMA engine is already up.
+ *
+ * There is no mainline driver for this Samsung EMR part yet (the downstream
+ * driver lives in kernel-src/drivers/input/wacom/). This node is staged for
+ * the PROBE-FIRST milestone: with AVDD always-on (wacom_avdd) the chip
+ * should ACK at 0x56 under `i2cdetect -y -r <bus>` even before a driver
+ * exists. Wiring transcribed from the stock wacom@56:
+ *   irq  -> &tlmm 51  (epen-int,  input, level-low)
+ *   fwe  -> &tlmm 54  (epen-fwe,  flash-enable, driver-owned)
+ *   pdct -> &tlmm 155 (epen-pdct, pen-detect, input)
+ *   avdd -> wacom_avdd (tlmm 167 fixed reg)
+ *   firmware wez01_gts8p.bin (harvested; tools/fw-manifest.tsv)
+ */
+&i2c14 {
+	clock-frequency = <400000>;
+	status = "okay";
+
+	wacom@56 {
+		compatible = "wacom,w90xx";
+		reg = <0x56>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <51 IRQ_TYPE_LEVEL_LOW>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&wacom_irq_default>, <&wacom_pdct_default>;
+
+		vdd-supply = <&wacom_avdd>;
+
+		wacom,irq-gpio = <&tlmm 51 GPIO_ACTIVE_LOW>;
+		wacom,fwe-gpio = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+		wacom,pdct-gpio = <&tlmm 155 GPIO_ACTIVE_LOW>;
+		wacom,fw_path = "wez01_gts8p.bin";
 	};
 };
 

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Wacom WEZ01 EMR digitizer (S Pen) — Samsung Galaxy Tab S8+ (gts8pwifi)
+ *
+ * A mainline-native first cut distilled from Samsung's downstream sec_input
+ * wacom driver (kernel-src/drivers/input/wacom/, ~10k lines). It keeps only the
+ * path that makes the pen draw: power on, query the chip, register an input
+ * device, and translate the 16-byte coordinate packet into pen events. Dropped
+ * for now — firmware flash (wez01_flash.c), BLE pen charging, AOP/screen-off
+ * gestures, the garage/dock notifier, and the factory sysfs.
+ *
+ * Chip: i2c 0x56 on &i2c14 (QUP SE14). Protocol + wiring are documented in
+ * device-facts/wacom-wez01.md. The chip already runs its app firmware (it ACKs
+ * cold), so no firmware load is needed to read it.
+ *
+ * Coordinate packet (COM_COORD_NUM = 16 bytes, read 17):
+ *   data[0]  header: rdy 0x80 (in range), tip 0x10, side-btn 0x20, eraser 0x40
+ *   data[1..2]  x   (big-endian)
+ *   data[3..4]  y
+ *   data[5..6]  pressure  (12-bit: (data[5] & 0x0f) << 8 | data[6])
+ *   data[7]     height (hover distance)
+ *   data[8]     tilt_x (signed)
+ *   data[9]     tilt_y (signed)
+ */
+
+#include <linux/delay.h>
+#include <linux/i2c.h>
+#include <linux/input.h>
+#include <linux/interrupt.h>
+#include <linux/module.h>
+#include <linux/mod_devicetable.h>
+#include <linux/regulator/consumer.h>
+#include <linux/slab.h>
+
+/* commands (subset of the downstream wacom_reg.h) */
+#define COM_QUERY		0x2a
+#define COM_SAMPLERATE_STOP	0x30
+#define COM_SAMPLERATE_START	0x31
+#define COM_SURVEY_EXIT		0x2d
+
+/* packet geometry (wacom_dev.h) */
+#define COM_COORD_NUM		16
+#define COM_QUERY_POS		16	/* query block trails one coord frame */
+#define COM_QUERY_BUFFER	32
+
+/* query block offsets (EPEN_REG_*) */
+#define QRY_HEADER		0x00	/* == 0x0f when the block is valid */
+#define QRY_X1			0x01
+#define QRY_X2			0x02
+#define QRY_Y1			0x03
+#define QRY_Y2			0x04
+#define QRY_PRESSURE1		0x05
+#define QRY_PRESSURE2		0x06
+#define QRY_FWVER1		0x07
+#define QRY_FWVER2		0x08
+#define QRY_MPUVER		0x09
+#define QRY_TILT_X		0x0b
+#define QRY_TILT_Y		0x0c
+#define QRY_HEIGHT		0x0d
+
+#define MPU_WEZ01		0x46
+
+/* coord header bits */
+#define HDR_RDY			0x80
+#define HDR_TIP			0x10
+#define HDR_SIDE		0x20
+#define HDR_ERASER		0x40
+
+/*
+ * Axis mapping from the stock DTB's wacom,invert = <0 1 1> — i.e.
+ * x_invert = 0, y_invert = 1, xy_switch = 1 — which rotates the digitizer's
+ * portrait frame into the panel's landscape frame. These are the values to
+ * revisit first if the pen draws mirrored or rotated (watch the raw packet
+ * log, enabled via the module's dyndbg, while moving the pen).
+ */
+#define WACOM_X_INVERT		0
+#define WACOM_Y_INVERT		1
+#define WACOM_XY_SWITCH		1
+
+struct wacom_wez01 {
+	struct i2c_client *client;
+	struct input_dev *input;
+	struct regulator *avdd;
+
+	u16 max_x;
+	u16 max_y;
+	u16 max_pressure;
+	u8 max_height;
+	s8 max_tilt;
+
+	bool prox;	/* pen currently in range (tool reported down) */
+};
+
+static int wacom_send(struct wacom_wez01 *w, u8 cmd)
+{
+	int ret = i2c_master_send(w->client, &cmd, 1);
+
+	return ret < 0 ? ret : 0;
+}
+
+/*
+ * Query the chip: send COM_QUERY, then read a 32-byte buffer whose second half
+ * (offset COM_QUERY_POS) carries the query block, tagged by header 0x0f. Fills
+ * the geometry fields; returns -EIO if the block never validates.
+ */
+static int wacom_query(struct wacom_wez01 *w)
+{
+	struct device *dev = &w->client->dev;
+	u8 buf[COM_QUERY_BUFFER];
+	u8 *q;
+	int ret, retry;
+
+	for (retry = 0; retry < 5; retry++) {
+		ret = wacom_send(w, COM_QUERY);
+		if (ret) {
+			dev_dbg(dev, "query cmd send failed: %d\n", ret);
+			msleep(20);
+			continue;
+		}
+		msleep(20);
+
+		ret = i2c_master_recv(w->client, buf, COM_QUERY_BUFFER);
+		if (ret != COM_QUERY_BUFFER) {
+			dev_dbg(dev, "query recv failed: %d\n", ret);
+			msleep(20);
+			continue;
+		}
+
+		q = buf + COM_QUERY_POS;
+		if (q[QRY_HEADER] != 0x0f) {
+			dev_dbg(dev, "query header %02x != 0x0f\n", q[QRY_HEADER]);
+			msleep(20);
+			continue;
+		}
+
+		w->max_x = ((u16)q[QRY_X1] << 8) | q[QRY_X2];
+		w->max_y = ((u16)q[QRY_Y1] << 8) | q[QRY_Y2];
+		w->max_pressure = ((u16)q[QRY_PRESSURE1] << 8) | q[QRY_PRESSURE2];
+		w->max_height = q[QRY_HEIGHT];
+		w->max_tilt = q[QRY_TILT_X];
+
+		dev_info(dev,
+			 "WEZ01 mpu=%02x fw=%02x%02x max_x=%u max_y=%u max_p=%u tilt=%d height=%u\n",
+			 q[QRY_MPUVER], q[QRY_FWVER1], q[QRY_FWVER2],
+			 w->max_x, w->max_y, w->max_pressure,
+			 w->max_tilt, w->max_height);
+
+		if (q[QRY_MPUVER] != MPU_WEZ01)
+			dev_warn(dev, "unexpected MPU id %02x (want %02x)\n",
+				 q[QRY_MPUVER], MPU_WEZ01);
+		return 0;
+	}
+
+	return -EIO;
+}
+
+/* Apply origin/invert/swap so events land in the panel's landscape frame. */
+static void wacom_map_axes(struct wacom_wez01 *w, u16 *x, u16 *y,
+			   s8 *tx, s8 *ty)
+{
+	if (WACOM_X_INVERT) {
+		*x = w->max_x - *x;
+		*tx = -*tx;
+	}
+	if (WACOM_Y_INVERT) {
+		*y = w->max_y - *y;
+		*ty = -*ty;
+	}
+	if (WACOM_XY_SWITCH) {
+		swap(*x, *y);
+		swap(*tx, *ty);
+	}
+}
+
+static irqreturn_t wacom_irq(int irq, void *dev_id)
+{
+	struct wacom_wez01 *w = dev_id;
+	struct input_dev *input = w->input;
+	u8 data[COM_COORD_NUM + 1];
+	u16 x, y, pressure;
+	s8 tilt_x, tilt_y;
+	u8 height;
+	int ret;
+
+	ret = i2c_master_recv(w->client, data, sizeof(data));
+	if (ret != sizeof(data)) {
+		dev_dbg(&w->client->dev, "coord recv failed: %d\n", ret);
+		return IRQ_HANDLED;
+	}
+
+	print_hex_dump_debug("wez01 pkt: ", DUMP_PREFIX_NONE, 16, 1,
+			     data, sizeof(data), false);
+
+	/* pen out of range: release everything once */
+	if (!(data[0] & HDR_RDY)) {
+		if (w->prox) {
+			input_report_abs(input, ABS_PRESSURE, 0);
+			input_report_abs(input, ABS_DISTANCE, 0);
+			input_report_key(input, BTN_TOUCH, 0);
+			input_report_key(input, BTN_STYLUS, 0);
+			input_report_key(input, BTN_TOOL_PEN, 0);
+			input_report_key(input, BTN_TOOL_RUBBER, 0);
+			input_sync(input);
+			w->prox = false;
+		}
+		return IRQ_HANDLED;
+	}
+
+	x = ((u16)data[1] << 8) | data[2];
+	y = ((u16)data[3] << 8) | data[4];
+	pressure = ((u16)(data[5] & 0x0f) << 8) | data[6];
+	height = data[7];
+	tilt_x = (s8)data[8];
+	tilt_y = (s8)data[9];
+
+	wacom_map_axes(w, &x, &y, &tilt_x, &tilt_y);
+
+	input_report_key(input, BTN_TOOL_RUBBER, !!(data[0] & HDR_ERASER));
+	input_report_key(input, BTN_TOOL_PEN, !(data[0] & HDR_ERASER));
+	input_report_key(input, BTN_TOUCH, !!(data[0] & HDR_TIP));
+	input_report_key(input, BTN_STYLUS, !!(data[0] & HDR_SIDE));
+	input_report_abs(input, ABS_X, x);
+	input_report_abs(input, ABS_Y, y);
+	input_report_abs(input, ABS_PRESSURE, pressure);
+	input_report_abs(input, ABS_DISTANCE, height);
+	input_report_abs(input, ABS_TILT_X, tilt_x);
+	input_report_abs(input, ABS_TILT_Y, tilt_y);
+	input_sync(input);
+
+	w->prox = true;
+	return IRQ_HANDLED;
+}
+
+static int wacom_setup_input(struct wacom_wez01 *w)
+{
+	struct input_dev *input;
+	u16 abs_x_max, abs_y_max;
+
+	input = devm_input_allocate_device(&w->client->dev);
+	if (!input)
+		return -ENOMEM;
+
+	input->name = "Wacom WEZ01 S Pen";
+	input->id.bustype = BUS_I2C;
+	input->dev.parent = &w->client->dev;
+
+	/* the abs ranges are in the post-swap (panel) frame */
+	if (WACOM_XY_SWITCH) {
+		abs_x_max = w->max_y;
+		abs_y_max = w->max_x;
+	} else {
+		abs_x_max = w->max_x;
+		abs_y_max = w->max_y;
+	}
+
+	input_set_capability(input, EV_KEY, BTN_TOUCH);
+	input_set_capability(input, EV_KEY, BTN_STYLUS);
+	input_set_capability(input, EV_KEY, BTN_TOOL_PEN);
+	input_set_capability(input, EV_KEY, BTN_TOOL_RUBBER);
+
+	input_set_abs_params(input, ABS_X, 0, abs_x_max, 4, 0);
+	input_set_abs_params(input, ABS_Y, 0, abs_y_max, 4, 0);
+	input_set_abs_params(input, ABS_PRESSURE, 0, w->max_pressure, 0, 0);
+	input_set_abs_params(input, ABS_DISTANCE, 0, w->max_height, 0, 0);
+	input_set_abs_params(input, ABS_TILT_X, -w->max_tilt, w->max_tilt, 0, 0);
+	input_set_abs_params(input, ABS_TILT_Y, -w->max_tilt, w->max_tilt, 0, 0);
+
+	__set_bit(INPUT_PROP_DIRECT, input->propbit);
+	__set_bit(INPUT_PROP_POINTER, input->propbit);
+
+	w->input = input;
+	return input_register_device(input);
+}
+
+static int wacom_probe(struct i2c_client *client)
+{
+	struct device *dev = &client->dev;
+	struct wacom_wez01 *w;
+	int ret;
+
+	if (!client->irq)
+		return dev_err_probe(dev, -EINVAL, "no IRQ\n");
+
+	w = devm_kzalloc(dev, sizeof(*w), GFP_KERNEL);
+	if (!w)
+		return -ENOMEM;
+
+	w->client = client;
+	i2c_set_clientdata(client, w);
+
+	/* sane fallbacks in case the query is unreadable */
+	w->max_x = 21658;
+	w->max_y = 13538;
+	w->max_pressure = 4095;
+	w->max_height = 255;
+	w->max_tilt = 63;
+
+	w->avdd = devm_regulator_get(dev, "vdd");
+	if (IS_ERR(w->avdd))
+		return dev_err_probe(dev, PTR_ERR(w->avdd), "no vdd regulator\n");
+
+	ret = regulator_enable(w->avdd);
+	if (ret)
+		return dev_err_probe(dev, ret, "cannot enable vdd\n");
+
+	/* let the analog front-end settle before the first transaction */
+	msleep(100);
+
+	ret = wacom_query(w);
+	if (ret)
+		dev_warn(dev, "query failed (%d); using fallback geometry\n", ret);
+
+	ret = wacom_setup_input(w);
+	if (ret)
+		goto err_disable;
+
+	ret = devm_request_threaded_irq(dev, client->irq, NULL, wacom_irq,
+					IRQF_ONESHOT, "wacom-wez01", w);
+	if (ret) {
+		dev_err(dev, "cannot request irq %d: %d\n", client->irq, ret);
+		goto err_disable;
+	}
+
+	/* start continuous sampling */
+	ret = wacom_send(w, COM_SAMPLERATE_START);
+	if (ret)
+		dev_warn(dev, "samplerate-start failed: %d\n", ret);
+
+	dev_info(dev, "Wacom WEZ01 S Pen ready on irq %d\n", client->irq);
+	return 0;
+
+err_disable:
+	regulator_disable(w->avdd);
+	return ret;
+}
+
+static void wacom_remove(struct i2c_client *client)
+{
+	struct wacom_wez01 *w = i2c_get_clientdata(client);
+
+	wacom_send(w, COM_SAMPLERATE_STOP);
+	regulator_disable(w->avdd);
+}
+
+static const struct of_device_id wacom_of_match[] = {
+	{ .compatible = "wacom,w90xx" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, wacom_of_match);
+
+static struct i2c_driver wacom_driver = {
+	.driver = {
+		.name = "wacom-wez01",
+		.of_match_table = wacom_of_match,
+	},
+	.probe = wacom_probe,
+	.remove = wacom_remove,
+};
+module_i2c_driver(wacom_driver);
+
+MODULE_DESCRIPTION("Wacom WEZ01 EMR digitizer (Samsung S Pen, gts8pwifi)");
+MODULE_LICENSE("GPL");

--- a/tools/fw-harvest.sh
+++ b/tools/fw-harvest.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# fw-harvest.sh — offline blob harvester for gts8pwifi.
+#
+# Reads tools/fw-manifest.tsv and copies the named Samsung/Qualcomm blobs out of
+# a pre-flash stock-firmware partition dump into a staging tree, then reports
+# coverage. Nothing here writes to a device or to flash — it only reads mounted
+# source roots and writes into --out.
+#
+# The intended flow (see docs/09-firmware-harvest.md):
+#   1. Unlock + root the tablet on stock (docs/01-unlock-root-runbook.md).
+#   2. dd the blob-bearing partitions off the rooted device: `apnhlos` and
+#      `super` (the runbook's step-8 backup already does this).
+#   3. Turn those raw images into source roots:
+#        apnhlos:  mount -o ro,loop apnhlos.img  /mnt/apnhlos
+#        vendor:   lpunpack --partition vendor super.img .  &&  \
+#                  mount -o ro,loop vendor.img  /mnt/vendor
+#      (--from-dumps does this for you when erofs/lp tooling is present.)
+#   4. Harvest into a staging tree, at leisure, on the host — BEFORE flashing:
+#        tools/fw-harvest.sh --apnhlos /mnt/apnhlos --vendor /mnt/vendor \
+#                            --out root-build/stock-extract/harvest
+#   5. The build stages from that tree and HARD-FAILS if a required blob is
+#      missing, so a bad harvest is caught before the user ever flashes.
+#
+# Usage:
+#   fw-harvest.sh [--manifest F] [--apnhlos DIR] [--vendor DIR] [--out DIR]
+#                 [--only NAME[,NAME...]] [--list]
+#   fw-harvest.sh --from-dumps DUMPDIR [--out DIR] [--only ...]   # raw .img in
+#
+# A source root that is not supplied is reported as SKIP (not an error) — you can
+# harvest just the apnhlos blobs, or just vendor, independently.
+
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+MANIFEST="$SELF_DIR/fw-manifest.tsv"
+OUT="$SELF_DIR/../root-build/stock-extract/harvest"
+APNHLOS=""
+VENDOR=""
+ONLY=""
+LIST=0
+FROM_DUMPS=""
+WORK=""
+
+die() { echo "!! $*" >&2; exit 1; }
+
+cleanup() { [ -n "$WORK" ] && { umount "$WORK"/mnt/* 2>/dev/null || true; rm -rf "$WORK" 2>/dev/null || true; }; }
+trap cleanup EXIT
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--manifest) MANIFEST=$2; shift 2 ;;
+		--apnhlos)  APNHLOS=$2; shift 2 ;;
+		--vendor)   VENDOR=$2; shift 2 ;;
+		--out)      OUT=$2; shift 2 ;;
+		--only)     ONLY=$2; shift 2 ;;
+		--from-dumps) FROM_DUMPS=$2; shift 2 ;;
+		--list)     LIST=1; shift ;;
+		-h|--help)  sed -n '2,40p' "$0"; exit 0 ;;
+		*) die "unknown arg: $1" ;;
+	esac
+done
+
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+
+# want NAME -> is it selected by --only?
+selected() {
+	[ -z "$ONLY" ] && return 0
+	case ",$ONLY," in *",$1,"*) return 0 ;; esac
+	return 1
+}
+
+# --list: print the manifest as a readable table, no harvesting.
+if [ "$LIST" -eq 1 ]; then
+	printf '%-12s %-8s %-6s %-8s %s\n' NAME SOURCE CLASS STATUS SRC_GLOB
+	while IFS=$(printf '\t') read -r name source glob dest tier class status notes; do
+		case "$name" in ''|\#*) continue ;; esac
+		printf '%-12s %-8s %-6s %-8s %s\n' "$name" "$source" "$class" "$status" "$glob"
+	done < "$MANIFEST"
+	exit 0
+fi
+
+# --from-dumps: build apnhlos/ and vendor/ source roots from raw partition images.
+if [ -n "$FROM_DUMPS" ]; then
+	[ "$(id -u)" -eq 0 ] || die "--from-dumps needs root (loop mounts / lpunpack)"
+	WORK=$(mktemp -d)
+	mkdir -p "$WORK/mnt/apnhlos" "$WORK/mnt/vendor"
+	if [ -f "$FROM_DUMPS/apnhlos.img" ]; then
+		mount -o ro,loop "$FROM_DUMPS/apnhlos.img" "$WORK/mnt/apnhlos" \
+			&& APNHLOS="$WORK/mnt/apnhlos" || echo "!! could not mount apnhlos.img" >&2
+	fi
+	if [ -f "$FROM_DUMPS/super.img" ]; then
+		command -v lpunpack >/dev/null || die "lpunpack not found (android-tools / lpunpack)"
+		lpunpack --partition vendor "$FROM_DUMPS/super.img" "$WORK" >/dev/null \
+			|| die "lpunpack of vendor from super.img failed"
+		mount -o ro,loop "$WORK/vendor.img" "$WORK/mnt/vendor" \
+			&& VENDOR="$WORK/mnt/vendor" \
+			|| die "could not mount vendor.img (erofs kernel support / erofs-utils needed)"
+	fi
+fi
+
+mkdir -p "$OUT"
+
+# resolve the mounted root for a given source name, or empty if not supplied
+root_for() {
+	case "$1" in
+		apnhlos) echo "$APNHLOS" ;;
+		vendor)  echo "$VENDOR" ;;
+		*)       echo "" ;;
+	esac
+}
+
+harvested=0 missing=0 skipped=0
+printf '%-12s %-8s %s\n' NAME SOURCE RESULT
+printf '%-12s %-8s %s\n' ------------ -------- ------
+
+while IFS=$(printf '\t') read -r name source glob dest tier class status notes; do
+	case "$name" in ''|\#*) continue ;; esac
+	selected "$name" || continue
+
+	root=$(root_for "$source")
+	if [ -z "$root" ]; then
+		printf '%-12s %-8s SKIP  (source not supplied)\n' "$name" "$source"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	# expand the glob within the source root
+	set +f
+	# shellcheck disable=SC2086
+	set -- $(cd "$root" 2>/dev/null && ls -1 $glob 2>/dev/null || true)
+	set -f
+	if [ "$#" -eq 0 ]; then
+		printf '%-12s %-8s MISS  (%s: no match for %s)\n' "$name" "$source" "$status" "$glob"
+		missing=$((missing + 1))
+		continue
+	fi
+
+	destdir="$OUT/$dest"
+	mkdir -p "$destdir"
+	n=0
+	for rel in "$@"; do
+		cp -f "$root/$rel" "$destdir/$(basename "$rel")"
+		n=$((n + 1))
+	done
+	printf '%-12s %-8s OK    (%d file(s) -> %s/)\n' "$name" "$source" "$n" "$dest"
+	harvested=$((harvested + 1))
+done < "$MANIFEST"
+
+echo
+echo ">> harvested $harvested, missing $missing, skipped $skipped  (staged in $OUT)"
+[ "$missing" -eq 0 ] || echo ">> NOTE: MISS on a working/wip row means the build gate should fail before flashing."

--- a/tools/fw-manifest.tsv
+++ b/tools/fw-manifest.tsv
@@ -1,0 +1,38 @@
+# fw-manifest.tsv — the blob harvest manifest for gts8pwifi.
+#
+# The cartridge-dump model (see docs/09-firmware-harvest.md):
+# this repo ships only OPEN or redistributable content. Every row below names a
+# Samsung/Qualcomm blob that lives in the builder's OWN stock firmware and is
+# copied out of a pre-flash partition dump at build time — nothing copyrighted
+# is ever distributed by us. One row per logical blob; tools/fw-harvest.sh reads
+# this file and stages the blobs a build actually needs.
+#
+# Columns (tab-separated):
+#   name     stable handle for the blob (also the harvest --only selector)
+#   source   which dumped partition/logical-image the blob lives in:
+#              apnhlos = plain vfat partition (mount -o ro)
+#              vendor  = EROFS logical image inside `super` (lpunpack + mount)
+#   src_glob path (glob ok) of the blob(s) WITHIN that source root
+#   dest_dir destination under /lib/firmware (. = the /lib/firmware root)
+#   tier     initramfs = must ride in the first-stage initramfs (loaded at
+#              driver bind, before rootfs mounts); rootfs = staged in /lib/firmware
+#   class    pil = Qualcomm PIL/MDT, TrustZone-authenticated (mdt + bNN splits)
+#            mcu = raw peripheral MCU image, flashed by its own driver over i2c/spi
+#            dsp = Cirrus/codec DSP firmware (wmfw + bin), loaded by ASoC
+#   status   working = a driver on our side consumes it today
+#            wip     = driver exists (often downstream) but not wired up on mainline
+#            none    = no mainline consumer yet; harvested for future bring-up
+#   notes
+#
+#name	source	src_glob	dest_dir	tier	class	status	notes
+a730_zap	apnhlos	image/a730_zap.*	qcom/sm8450/gts8pwifi	initramfs	pil	working	GPU zap shader; TZ will only accept Samsung's signature. The working reference.
+wez01_pen	vendor	firmware/wez01_gts8p.bin	.	rootfs	mcu	wip	S Pen Wacom W90xx digitizer (i2c 0x56, DT wacom,fw_path). Downstream driver in kernel-src/drivers/input/wacom/.
+fts_touch	vendor	firmware/tsp_stm/fts1ba90a_gts8p.bin	.	rootfs	mcu	working	Touchscreen (STM FTS1BA90A). Already ported; driver flashes this over i2c.
+stm32_pogo	vendor	firmware/keyboard_stm/stm32_gts8p.bin	.	rootfs	mcu	working	Pogo Book Cover Keyboard MCU. Already ported (stm32-pogo). Flash is byte-identical to this.
+camera_icp	vendor	firmware/CAMERA_ICP.*	qcom/sm8450/gts8pwifi	rootfs	pil	none	Camera ISP microcontroller (Xtensa PIL). No mainline CAMSS/ICP path on this SoC yet.
+eva	vendor	firmware/evass.*	qcom/sm8450/gts8pwifi	rootfs	pil	none	EVA computer-vision engine (Xtensa PIL). evass-lt-21.* is the low-temp variant.
+vpu	vendor	firmware/vpu20_*.mbn	qcom/sm8450/gts8pwifi	rootfs	pil	none	Iris video codec (Xtensa PIL). Note: signed + _unsigned variants both ship.
+cs35l45	vendor	firmware/cs35l45-*	.	rootfs	dsp	none	Cirrus CS35L45 smart speaker amp DSP (wmfw + tuning bins). Relevant to the audio path.
+cs40l26	vendor	firmware/cs40l26*	.	rootfs	dsp	none	Cirrus CS40L26 haptics DSP.
+mfc	vendor	firmware/mfc/mfc_fw_flash.bin	.	rootfs	mcu	none	MFC wireless-charging IC MCU image.
+ois	vendor	firmware/ois_mcu_stm32g_fw.bin	.	rootfs	mcu	none	Camera OIS STM32G MCU image.


### PR DESCRIPTION
## Summary

- **S Pen works** — Wacom WEZ01 EMR digitizer now reports position, pressure, and tool detection on mainline. SE14's FIFO is disabled in silicon (forces broken GPI DMA), so we bit-bang i2c on its pins via `i2c-gpio`; the bus-agnostic `wacom-wez01` driver moved buses with zero code change.
- **Firmware harvest pattern** — generalized the one-off GPU-zap extractor into a manifest-driven harvester (`tools/fw-manifest.tsv` + `tools/fw-harvest.sh`) that pulls non-redistributable blobs from the builder's own stock firmware. Plus `make check-tools`.
- Console-first boot default; `device-facts/wacom-wez01.md` documents the full bring-up and the GPI-DMA diagnosis.

## Test plan

- Verified on-device (SM-X800, r44 kernel): pen draws — `ABS_X/Y` track strokes, `ABS_PRESSURE` analog to ~3500/4095, `BTN_TOOL_PEN` on proximity, no bus errors. `i2c-gpio` bus enumerated, geni `&i2c14` disabled.
- Harvester tested against the local stock super/vendor dump: 10/10 vendor blobs, PIL split-sets resolved.

## Known follow-ups (polish, not blockers)
- `COM_QUERY` returns -5 → calibration on fallback geometry.
- Axis orientation not yet verified against the panel.