### PR TITLE
S Pen query works: repeated-start i2c_transfer reads real geometry

### DIFF
--- a/device-facts/wacom-wez01.md
+++ b/device-facts/wacom-wez01.md
@@ -43,8 +43,10 @@ while drawing), as expected for a passive EMR stylus.
 
 ## Protocol (from the downstream driver)
 
-**Query** — send `COM_QUERY` (`0x2A`), read back a buffer; the query block starts
-where `query[0] == 0x0F` (EPEN_REG_HEADER). Big-endian pairs:
+**Query** — write `COM_QUERY` (`0x2A`) then read the buffer **as one combined
+`i2c_transfer` (repeated start, no STOP between)**; the query block lands at
+**offset 0** of the read, tagged by `query[0] == 0x0F` (EPEN_REG_HEADER). Big-endian
+pairs:
 
 ```
 max_x        = query[1]<<8 | query[2]
@@ -56,6 +58,10 @@ bl_ver       = query[10]
 tilt_x/y     = query[11], query[12]
 height       = query[13]
 ```
+
+Confirmed live on this unit (dmesg):
+`mpu=46 fw=400e max_x=26712 max_y=16714 max_p=4095 tilt=63 height=255`. Note the
+real geometry (26712×16714) is larger than the old fallback guess (21658×13538).
 
 **Coordinate packet** — `COM_COORD_NUM = 16` bytes (read 17). `data[0]` is the
 header; low nibble is the packet type (`NOTI_PACKET = 13`, else pen data):
@@ -112,12 +118,13 @@ bit-banged `i2c-gpio` bus** on the same pins (gpio52/53). See the DTS comment on
 `&wacom_i2c`.
 
 Open polish (not blockers):
-- `wacom_i2c_query` (`COM_QUERY` write, then 32-byte read) still returns -5 even
-  post-boot, so the driver runs on fallback `max_x/max_y` — calibration is
-  approximate. Likely the query wants a repeated-start (combined write+read via a
-  2-message `i2c_transfer`, which the bit-bang bus supports) rather than two
-  separate transactions; or the reply arrives via IRQ. Fixing it gives exact
-  geometry + an `mpu == 0x46` liveness check.
+- ~~`wacom_i2c_query` returns -5~~ **FIXED.** Two faults compounded: (1) the
+  separate `COM_QUERY` write + read issued a STOP and re-addressed the chip
+  between them, dropping the WEZ01's command latch on the bit-bang bus; (2) the
+  old code then read the query block at offset 16 (where a stale coord frame
+  would sit). A single combined `i2c_transfer` (repeated start) fixes (1) and
+  returns the block at **offset 0**, fixing (2). Verified: `mpu=0x46`, exact
+  geometry now feeds the input device's ABS ranges (was on fallback).
 - Axis orientation (hardcoded from stock `wacom,invert = <0 1 1>`) not yet
   verified against the panel with directed strokes.
 - Tilt/height reported but not eyeballed.

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
@@ -40,7 +40,6 @@
 
 /* packet geometry (wacom_dev.h) */
 #define COM_COORD_NUM		16
-#define COM_QUERY_POS		16	/* query block trails one coord frame */
 #define COM_QUERY_BUFFER	32
 
 /* query block offsets (EPEN_REG_*) */
@@ -99,34 +98,48 @@ static int wacom_send(struct wacom_wez01 *w, u8 cmd)
 }
 
 /*
- * Query the chip: send COM_QUERY, then read a 32-byte buffer whose second half
- * (offset COM_QUERY_POS) carries the query block, tagged by header 0x0f. Fills
- * the geometry fields; returns -EIO if the block never validates.
+ * Query the chip with a single combined transfer: write COM_QUERY then read the
+ * buffer under a repeated start (no STOP between the two messages). The query
+ * block lands at the start of the read, tagged by header 0x0f. Fills the
+ * geometry fields; returns -EIO if the block never validates.
+ *
+ * A repeated start is load-bearing on the bit-bang i2c-gpio bus: the separate
+ * send + recv path issues a STOP and re-addresses the chip between the command
+ * and the read, which dropped the WEZ01's command latch — so the read came back
+ * as a stale coord frame (block shifted to offset 16, header always 0xff) and
+ * never validated. The combined transfer returns the block at offset 0.
  */
 static int wacom_query(struct wacom_wez01 *w)
 {
 	struct device *dev = &w->client->dev;
+	u8 cmd = COM_QUERY;
 	u8 buf[COM_QUERY_BUFFER];
+	struct i2c_msg msgs[] = {
+		{
+			.addr = w->client->addr,
+			.flags = 0,
+			.len = 1,
+			.buf = &cmd,
+		},
+		{
+			.addr = w->client->addr,
+			.flags = I2C_M_RD,
+			.len = COM_QUERY_BUFFER,
+			.buf = buf,
+		},
+	};
 	u8 *q;
 	int ret, retry;
 
 	for (retry = 0; retry < 5; retry++) {
-		ret = wacom_send(w, COM_QUERY);
-		if (ret) {
-			dev_dbg(dev, "query cmd send failed: %d\n", ret);
-			msleep(20);
-			continue;
-		}
-		msleep(20);
-
-		ret = i2c_master_recv(w->client, buf, COM_QUERY_BUFFER);
-		if (ret != COM_QUERY_BUFFER) {
-			dev_dbg(dev, "query recv failed: %d\n", ret);
+		ret = i2c_transfer(w->client->adapter, msgs, ARRAY_SIZE(msgs));
+		if (ret != ARRAY_SIZE(msgs)) {
+			dev_dbg(dev, "query transfer failed: %d\n", ret);
 			msleep(20);
 			continue;
 		}
 
-		q = buf + COM_QUERY_POS;
+		q = buf;
 		if (q[QRY_HEADER] != 0x0f) {
 			dev_dbg(dev, "query header %02x != 0x0f\n", q[QRY_HEADER]);
 			msleep(20);


### PR DESCRIPTION
## What

Fixes `wacom_query` returning `-EIO` (-5) since bring-up. The pen worked but on **guessed fallback geometry** (21658×13538); now it reads the WEZ01's real geometry from the chip.

## Root cause (two compounding faults)

1. **STOP dropped the command latch.** The separate `COM_QUERY` write + read issued a STOP and re-addressed the chip between command and read. On the bit-bang `i2c-gpio` bus that drops the WEZ01's command latch, so the read came back as a stale coord frame.
2. **Wrong offset.** The old code read the query block at offset 16 (`COM_QUERY_POS`) — where a leading coord frame sits in the send/recv path. With a clean read the block starts at **offset 0**, so offset 16 was always `0xff` and the `0x0f` header never validated.

## Fix

Single combined `i2c_transfer` (write `0x2a` then read 32 under a repeated start) + read the block at offset 0. Drops the now-unused `COM_QUERY_POS`.

## Verified on-device (SM-X800)

```
wacom-wez01 0-0056: WEZ01 mpu=46 fw=400e max_x=26712 max_y=16714 max_p=4095 tilt=63 height=255
```

- `mpu=0x46` confirms the WEZ01 (live liveness check, previously impossible).
- Input device ABS ranges now carry real geometry: `ABS_X` max 16714, `ABS_Y` max 26712 (after `xy_switch`), pressure 4095, distance 255, tilt ±63.
- Live pen strokes still track with pressure and tilt (captured via evtest).

Device-fact note (`device-facts/wacom-wez01.md`) updated: query section documents the repeated-start + offset-0 requirement and the confirmed values; the "returns -5" polish item marked fixed.

## Not in scope

Axis orientation (DO NEXT #2) — the `wacom,invert = <0 1 1>` mapping is still unverified against the panel with directed strokes.