### PR TITLE
S Pen usable in KDE/Wayland: libinput resolution + identity axis map

### DIFF
--- a/device-facts/wacom-wez01.md
+++ b/device-facts/wacom-wez01.md
@@ -117,6 +117,10 @@ pen off geni (which is forced to broken GPI DMA on SE14) onto a **software
 bit-banged `i2c-gpio` bus** on the same pins (gpio52/53). See the DTS comment on
 `&wacom_i2c`.
 
+Usable as a **KDE Plasma (Wayland) input device** — verified: KWin binds it via
+libinput and the cursor tracks the pen tip 1:1. Two fixes past raw evdev were
+needed to get there (below).
+
 Open polish (not blockers):
 - ~~`wacom_i2c_query` returns -5~~ **FIXED.** Two faults compounded: (1) the
   separate `COM_QUERY` write + read issued a STOP and re-addressed the chip
@@ -125,9 +129,30 @@ Open polish (not blockers):
   would sit). A single combined `i2c_transfer` (repeated start) fixes (1) and
   returns the block at **offset 0**, fixing (2). Verified: `mpu=0x46`, exact
   geometry now feeds the input device's ABS ranges (was on fallback).
-- Axis orientation (hardcoded from stock `wacom,invert = <0 1 1>`) not yet
-  verified against the panel with directed strokes.
+- ~~libinput ignored the pen~~ **FIXED.** Raw evdev/evtest and udev
+  (`ID_INPUT_TABLET=1`) were all happy, but the pen did nothing in KWin because
+  libinput rejected it: *"missing tablet capabilities: resolution. Ignoring this
+  device."* libinput hard-requires a non-zero `ABS_X`/`ABS_Y` resolution for
+  tablet tools. The WEZ01's 26712 x 16714 units span the 12.4" 16:10 active area
+  (267.1 x 166.9 mm) = **100 units/mm**, the usual Wacom EMR density; set via
+  `input_abs_set_res()`. libinput then reports the tool as `267x167mm`.
+- ~~Axis orientation~~ **FIXED — mapping is identity.** Measured in a KWin
+  session: the raw digitizer frame already matches the panel's landscape frame —
+  `raw_x` horizontal (L->R, 0..max_x), `raw_y` vertical (T->B, 0..max_y), neither
+  inverted. The stock `wacom,invert = <0 1 1>` is in Samsung's *post-rotation*
+  frame (see the DTS touchscreen comment) and applying it literally rotated +
+  mirrored the cursor. Set `x_invert=y_invert=xy_switch=0`.
 - Tilt/height reported but not eyeballed.
+
+**Gotcha — capturing raw pen data while a compositor runs.** KWin (via
+logind/libinput) takes an `EVIOCGRAB` on the tablet, so a concurrent
+`evtest /dev/input/event2` receives *zero* events even though the pen is firing
+(watch the delta on `/proc/interrupts` IRQ 177 to confirm it's alive). To capture
+raw coords, stop the compositor (`systemctl isolate multi-user.target`) or test
+at a fresh console boot before starting Plasma. Note the digitizer can also come
+up wedged after a *warm* reboot (fires IRQs, emits no input events) — a clean
+boot after a flash clears it. Orientation itself was derivable from the in-session
+tracking behavior without a raw capture.
 
 ## History: why geni/GPI DMA did not work (the road here)
 

--- a/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
+++ b/pmaports-overlay/device/testing/linux-postmarketos-qcom-sm8450/wacom-wez01.c
@@ -59,6 +59,9 @@
 
 #define MPU_WEZ01		0x46
 
+/* digitizer density: 100 units/mm across the 12.4" 16:10 active area */
+#define WACOM_RES_UNITS_PER_MM	100
+
 /* coord header bits */
 #define HDR_RDY			0x80
 #define HDR_TIP			0x10
@@ -66,15 +69,21 @@
 #define HDR_ERASER		0x40
 
 /*
- * Axis mapping from the stock DTB's wacom,invert = <0 1 1> — i.e.
- * x_invert = 0, y_invert = 1, xy_switch = 1 — which rotates the digitizer's
- * portrait frame into the panel's landscape frame. These are the values to
- * revisit first if the pen draws mirrored or rotated (watch the raw packet
- * log, enabled via the module's dyndbg, while moving the pen).
+ * Axis mapping: identity. Measured on-device (strokes tracked in a KWin/Wayland
+ * session), the raw digitizer frame already matches the panel's landscape frame
+ * — raw_x is horizontal (left->right, 0..max_x) and raw_y is vertical
+ * (top->bottom, 0..max_y), both un-inverted. The stock DTB's
+ * wacom,invert = <0 1 1> hint is expressed in Samsung's post-rotation frame (see
+ * the touchscreen node's comment in the DTS) and does NOT apply to the raw
+ * coords the mainline i2c read returns; using it rotated + mirrored the cursor.
+ *
+ * If a future panel draws mirrored or rotated, these are the knobs: flip an
+ * invert for a mirror, set xy_switch for a 90-degree rotation. Confirm with a
+ * three-corner raw capture (evtest) rather than guessing.
  */
 #define WACOM_X_INVERT		0
-#define WACOM_Y_INVERT		1
-#define WACOM_XY_SWITCH		1
+#define WACOM_Y_INVERT		0
+#define WACOM_XY_SWITCH		0
 
 struct wacom_wez01 {
 	struct i2c_client *client;
@@ -277,6 +286,16 @@ static int wacom_setup_input(struct wacom_wez01 *w)
 	input_set_abs_params(input, ABS_DISTANCE, 0, w->max_height, 0, 0);
 	input_set_abs_params(input, ABS_TILT_X, -w->max_tilt, w->max_tilt, 0, 0);
 	input_set_abs_params(input, ABS_TILT_Y, -w->max_tilt, w->max_tilt, 0, 0);
+
+	/*
+	 * libinput refuses a tablet tool that reports no X/Y resolution
+	 * ("missing tablet capabilities: resolution. Ignoring this device"),
+	 * so KWin/Wayland never sees the pen. The WEZ01 reports 26712 x 16714
+	 * units across the 12.4" 16:10 active area (267.1 x 166.9 mm) = 100
+	 * units/mm on both axes, the usual Wacom EMR density.
+	 */
+	input_abs_set_res(input, ABS_X, WACOM_RES_UNITS_PER_MM);
+	input_abs_set_res(input, ABS_Y, WACOM_RES_UNITS_PER_MM);
 
 	__set_bit(INPUT_PROP_DIRECT, input->propbit);
 	__set_bit(INPUT_PROP_POINTER, input->propbit);


### PR DESCRIPTION
## What

Makes the S Pen actually usable in a KDE Plasma (Wayland) session. Raw evdev/evtest and udev (`ID_INPUT_TABLET=1`) were already happy, but the pen did nothing under KWin. Two independent faults:

### 1. Missing ABS resolution → libinput rejected the device
libinput hard-requires a non-zero `ABS_X`/`ABS_Y` resolution for tablet tools:
```
event2 - Wacom WEZ01 S Pen: libinput bug: missing tablet capabilities: resolution. Ignoring this device.
```
So KWin never saw the pen. The WEZ01's 26712×16714 units span the 12.4" 16:10 active area (267.1×166.9 mm) = **100 units/mm** (usual Wacom EMR density); reported via `input_abs_set_res()`.

### 2. Wrong orientation → cursor rotated + mirrored
The mapping was carried from the stock `wacom,invert=<0 1 1>`, but that hint is in Samsung's *post-rotation* frame (the DTS touchscreen comment flags this). Measured in a live KWin session, the raw digitizer frame already matches the panel's landscape frame (`raw_x` horizontal L→R, `raw_y` vertical T→B, neither inverted), so the correct mapping is **identity**: `x_invert=y_invert=xy_switch=0`.

## Verified on-device (SM-X800)

- `libinput list-devices` now: `Size: 267x167mm`, `Capabilities: tablet` (was "Ignoring this device").
- Plasma Wayland: cursor tracks the pen tip 1:1 — center-left edge → center-left, drag-down → straight down, diagonals track diagonally.

## Notes

- `device-facts/wacom-wez01.md` updated with both fixes and a gotcha: KWin takes an `EVIOCGRAB` on the tablet, so a concurrent `evtest` sees zero events while Plasma runs (confirm liveness via `/proc/interrupts` IRQ 177); capture raw coords at a console with the compositor stopped.

## Not in scope

Tilt/height are reported but not yet eyeballed for accuracy.